### PR TITLE
Handle non-json error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/node",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/node",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "MOST Web Framework NodeJS Client Module",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,6 +107,8 @@ export class NodeDataService extends ClientDataService {
                                     delete err.status;
                                 }
                                 return Promise.reject(err);
+                            }).catch(err=>{
+                                return Promise.reject(Object.assign(err,{response:res}));
                             });
                         }
                     })


### PR DESCRIPTION
Some times  the content type of the response is json-like (application/json) but the response is not a json object